### PR TITLE
add timeout

### DIFF
--- a/src/scanner/scanNFTStats.ts
+++ b/src/scanner/scanNFTStats.ts
@@ -25,7 +25,11 @@ const range = (start, stop) =>
 	Array.from({ length: stop - start + 1 }, (_, i) => start + i);
 
 async function main() {
-	const api = await Api.create({ provider: process.env.PROVIDER });
+	const TIMEOUT_MS = 120 * 1000;
+	const api = await Api.create({
+		provider: process.env.PROVIDER,
+		timeout: TIMEOUT_MS,
+	});
 	await mongoose.connect(process.env.MONGO_URI);
 	await fetchSupportedAssets(api);
 	let fetchOldData = process.env.USE_UNCOVER;

--- a/src/scanner/utils/fetchNFTBlockNumberForRange.ts
+++ b/src/scanner/utils/fetchNFTBlockNumberForRange.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {logger} from "@/src/logger";
+import { logger } from "@/src/logger";
 
 export async function fetchNFTBlockFromUncoverForRange(start, end) {
 	let startDate = new Date(start);
@@ -20,7 +20,10 @@ export async function fetchNFTBlockFromUncoverForRange(start, end) {
 			let nftResponse;
 			let utilityResponse;
 			if (moreNFTsExists && moreUtilityBatchExists) {
-				[nftResponse, utilityResponse] = await Promise.all([axios.get(urlWithNFT), axios.get(urlWithBatch)]);
+				[nftResponse, utilityResponse] = await Promise.all([
+					axios.get(urlWithNFT),
+					axios.get(urlWithBatch),
+				]);
 			} else if (moreNFTsExists) {
 				nftResponse = await axios.get(urlWithNFT);
 			} else if (moreUtilityBatchExists) {
@@ -28,8 +31,10 @@ export async function fetchNFTBlockFromUncoverForRange(start, end) {
 			}
 			nftBlockNumbers = nftResponse?.data?.data;
 			batchTxBlockNumbers = utilityResponse?.data?.data;
-			moreNFTsExists = nftBlockNumbers && nftBlockNumbers.length > 0 ? true : false;
-			moreUtilityBatchExists = batchTxBlockNumbers && batchTxBlockNumbers.length > 0 ? true : false;
+			moreNFTsExists =
+				nftBlockNumbers && nftBlockNumbers.length > 0 ? true : false;
+			moreUtilityBatchExists =
+				batchTxBlockNumbers && batchTxBlockNumbers.length > 0 ? true : false;
 			page = page + 1;
 			if (moreNFTsExists) {
 				globalBlockNumbers = globalBlockNumbers.concat(nftBlockNumbers);


### PR DESCRIPTION
Closes https://github.com/cennznet/api-nft/issues/15

From cloud watch, appears that having timeout will make it wait for a while before it throws
No response received from RPC endpoint in ${this.#timeout / 1000}s`
